### PR TITLE
Fix JSON error when no schema block

### DIFF
--- a/src/schemaParser.ts
+++ b/src/schemaParser.ts
@@ -97,7 +97,7 @@ export class SchemaParser {
             return {
                 schema: null,
                 issues: [],
-                originalError: 'No schema block found'
+                originalError: null
             };
         }
 


### PR DESCRIPTION
## Summary
- ensure parseDocument skips JSON parsing when no schema block is present

## Testing
- `npm run -s compile`

------
https://chatgpt.com/codex/tasks/task_e_6844d63ae290832cbe6d160ea2f5010b