### PR TITLE
Fix schema parsing with whitespace control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 All notable changes to the Shopify Schema Helper extension will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.1] - 2025-06-09
+
+### Fixed
+- Schema detection now recognizes whitespace-trimmed tags `{%- schema -%}` and `{%- endschema -%}`.
 
 ## [0.2.0] - 2024-12-XX
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A powerful VS Code extension that makes it easy to visualize and validate Shopif
 - Instant parsing of Shopify section and block schemas
 - Visual representation of settings, blocks, and presets
 - Support for both section and theme block schemas
+- Recognizes schema tags with whitespace control (`{%- schema -%}`)
 
 ### ✅ **Advanced Schema Validation**
 - Real-time validation with detailed error messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "shopify-schema-helper",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shopify-schema-helper",
-      "version": "0.1.0",
+      "version": "0.2.1",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "16.x",
         "@types/vscode": "^1.74.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shopify-schema-helper",
   "displayName": "Shopify Schema Helper",
   "description": "Visualize Shopify section and block schemas with ease",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "luizventurote",
   "icon": "media/shopify-schema-helper-logo.png",
   "author": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export function activate(context: vscode.ExtensionContext) {
         
         // Also check for common JSON syntax issues using the parser's validator
         const text = document.getText();
-        const schemaMatch = text.match(/{%\s*schema\s*%}([\s\S]*?){%\s*endschema\s*%}/i);
+        const schemaMatch = text.match(/\{%-?\s*schema\s*-?%\}([\s\S]*?)\{%-?\s*endschema\s*-?%\}/i);
         
         if (schemaMatch) {
             const schemaContent = schemaMatch[1].trim();
@@ -97,7 +97,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     function createPreciseJsonDiagnostic(document: vscode.TextDocument, error: any): vscode.Diagnostic | null {
         const text = document.getText();
-        const schemaMatch = text.match(/{%\s*schema\s*%}([\s\S]*?){%\s*endschema\s*%}/i);
+        const schemaMatch = text.match(/\{%-?\s*schema\s*-?%\}([\s\S]*?)\{%-?\s*endschema\s*-?%\}/i);
         
         if (!schemaMatch) {
             return null;

--- a/src/schemaParser.ts
+++ b/src/schemaParser.ts
@@ -91,7 +91,7 @@ export class SchemaParser {
 
     public parseDocument(document: vscode.TextDocument): ParseResult {
         const text = document.getText();
-        const schemaMatch = text.match(/{%\s*schema\s*%}([\s\S]*?){%\s*endschema\s*%}/i);
+        const schemaMatch = text.match(/\{%-?\s*schema\s*-?%\}([\s\S]*?)\{%-?\s*endschema\s*-?%\}/i);
         
         if (!schemaMatch) {
             return {

--- a/src/schemaTreeProvider.ts
+++ b/src/schemaTreeProvider.ts
@@ -66,7 +66,7 @@ export class SchemaTreeDataProvider implements vscode.TreeDataProvider<SchemaTre
         }
 
         const text = document.getText();
-        const schemaMatch = text.match(/{%\s*schema\s*%}([\s\S]*?){%\s*endschema\s*%}/i);
+        const schemaMatch = text.match(/\{%-?\s*schema\s*-?%\}([\s\S]*?)\{%-?\s*endschema\s*-?%\}/i);
         
         if (!schemaMatch) {
             return;
@@ -88,7 +88,7 @@ export class SchemaTreeDataProvider implements vscode.TreeDataProvider<SchemaTre
 
     private buildSchemaLineMap(document: vscode.TextDocument): void {
         const text = document.getText();
-        const schemaMatch = text.match(/{%\s*schema\s*%}([\s\S]*?){%\s*endschema\s*%}/i);
+        const schemaMatch = text.match(/\{%-?\s*schema\s*-?%\}([\s\S]*?)\{%-?\s*endschema\s*-?%\}/i);
         
         if (!schemaMatch) {
             return;


### PR DESCRIPTION
## Summary
- handle `{%- schema -%}` tags when extracting schema blocks
- document new whitespace control support
- bump version to 0.2.1 and update changelog

## Testing
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_68470ca63114832ca30193772c2c43e8